### PR TITLE
fix license link for jquery-ui

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <licenses>
         <license>
             <name>MIT License</name>
-            <url>https://github.com/jquery/jquery-ui/blob/master/MIT-LICENSE.txt</url>
+            <url>https://github.com/jquery/jquery-ui/blob/master/LICENSE.txt</url>
             <distribution>repo</distribution>
         </license>
     </licenses>


### PR DESCRIPTION
The license file is renamed in upstream repository.
